### PR TITLE
Update common.py

### DIFF
--- a/common.py
+++ b/common.py
@@ -10,7 +10,7 @@ from py4web.utils.mailer import Mailer
 from py4web.utils.auth import Auth
 from py4web.utils.form import FormStyleBootstrap4
 from py4web.utils.downloader import downloader
-from py4web.utils.tags import Tags
+from pydal.tools.tags import Tags
 from py4web.utils.factories import ActionFactory
 from . import settings
 


### PR DESCRIPTION
 Replaced py4web.utils.tags with pydal.tools.tags in import statement in response to deprecation warning.